### PR TITLE
Find bases using resource graph

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ aiohttp = "*"
 pyglet = "*"
 numpy = "*"
 scipy = "*"
+networkx = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8dfffc5b49e3a2a05cf1a339d89c4285b25483f8a3ead83ec8655e956bbe5875"
+            "sha256": "8f293ab7f583c97bf8017b9ee82158d89ca79b0980bd899b19429a62ca0b207f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -58,6 +58,13 @@
             ],
             "version": "==3.0.4"
         },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
+        },
         "future": {
             "hashes": [
                 "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
@@ -104,6 +111,13 @@
                 "sha256:db603a1c235d110c860d5f39988ebc8218ee028f07a7cbc056ba6424372ca31b"
             ],
             "version": "==4.5.2"
+        },
+        "networkx": {
+            "hashes": [
+                "sha256:8311ddef63cf5c5c5e7c1d0212dd141d9a1fe3f474915281b73597ed5f1d4e3d"
+            ],
+            "index": "pypi",
+            "version": "==2.3"
         },
         "numpy": {
             "hashes": [
@@ -266,14 +280,6 @@
             ],
             "index": "pypi",
             "version": "==2.0.15"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
-                "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.1"
         },
         "coverage": {
             "hashes": [

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -215,11 +215,11 @@ class BotAI(DistanceCalculation):
         geysers = self.vespene_geyser
         resource_graph = networkx.Graph()
         resources = [ resource for resource in self.resources if resource.name != 'MineralField450']
-        for resource_a in self.resources:
+        for resource_a in resources:
             resource_graph.add_node(resource_a)
             resource_graph.add_edges_from([
                 (resource_a, resource_b)
-                for resource_b in self.resources
+                for resource_b in resources
                 if resource_a.distance_to(resource_b) <= resource_spread_threshold
                 # checking z-position separates adjacent bases on different levels
                 and abs(resource_a.position3d.z - resource_b.position3d.z) <= 0.1

--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -222,7 +222,7 @@ class BotAI(DistanceCalculation):
                 for resource_b in resources
                 if resource_a.distance_to(resource_b) <= resource_spread_threshold
                 # checking z-position separates adjacent bases on different levels
-                and abs(resource_a.position3d.z - resource_b.position3d.z) <= 0.1
+                and abs(resource_a.position3d.z - resource_b.position3d.z) <= 0.5
             ])
 
         # separate into groups based on which nodes are "connected" (within the threshold)


### PR DESCRIPTION
This changes the expansion_locations algorithm to use a graph data structure, connecting nearby resource nodes and finding groups of connected nodes in the graph.

Originally, I did this in an attempt to resolve the issues with path-blocking minerals on World of Sleepers, not knowing that there was, and that you were about to implement, a simpler solution to that problem (ignore `MineralField450`). Still, I think the result is a little more elegant and the data structure may provide other options down the road. 

Since you already fixed the issue I mentioned above, the only functional _change_ here is that it requires resource nodes within a base to be the same height, which would be easy to remove, and doesn't fix any maps that I'm aware of.

If you don't want to make this change, that's fine -- I'm only opening this PR because I think the graph algorithm is a little more straightforward. 