### PR TITLE
Add support for running in different wine versions

### DIFF
--- a/sc2/paths.py
+++ b/sc2/paths.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import re
+import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,25 @@ PF = os.environ.get("SC2PF", platform.system())
 def get_env():
     # TODO: Linux env conf from: https://github.com/deepmind/pysc2/blob/master/pysc2/run_configs/platforms.py
     return None
+
+def get_runner_args(cwd):
+    if "WINE" in os.environ:
+        runner_dir = os.path.dirname(os.environ.get("WINE"))
+        # translate cwd from Unix to Windows path
+        win_cwd = subprocess.run(
+            [os.path.join(runner_dir, "winepath"), "-w", cwd],
+            capture_output=True,
+            text=True
+        ).stdout.rstrip()
+        return [
+            os.environ.get("WINE"),
+            "start",
+            "/d",
+            win_cwd,
+            "/unix"
+        ]
+
+    return []
 
 def latest_executeble(versions_dir, base_build=None):
 

--- a/sc2/sc2process.py
+++ b/sc2/sc2process.py
@@ -114,7 +114,7 @@ class SC2Process:
             executable = str(paths.latest_executeble(Paths.BASE / "Versions", self._base_build))
         else:
             executable = str(Paths.EXECUTABLE)
-        args = [
+        args = paths.get_runner_args(Paths.CWD) + [
             executable,
             "-listen",
             self._host,


### PR DESCRIPTION
In 33a42149569c76319b97fad1d7376789d1590562 some basic support for wine was added.
However it works only if wine is installed system wide and associated with .exe mime type.
This commit allows using different versions - including versions installed via Lutris.

btw. This approach doesn't require having `WineLinux` as a separate platform. Example:

`WINE=/home/kk/.local/share/lutris/runners/wine/ge-protonified-nofshack-4.9-x86_64/bin/wine WINEDEBUG="-all" WINEPREFIX=/mnt/s1/wine/sc2-default WINEARCH=win64 SC2PF=Windows SC2PATH="/mnt/s1/wine/sc2-default/dosdevices/z:/mnt/s1/BnetGameLib/StarCraft II" python3 examples/protoss/cannon_rush.py`

![Selection_3887dc2e](https://user-images.githubusercontent.com/6976458/67836618-63cbbb00-faed-11e9-824c-7106010bb175.png)
