### PR TITLE
Allow disabling of fog of war

### DIFF
--- a/sc2/controller.py
+++ b/sc2/controller.py
@@ -17,9 +17,9 @@ class Controller(Protocol):
     def running(self):
         return self.__process._process is not None
 
-    async def create_game(self, game_map, players, realtime, random_seed=None):
+    async def create_game(self, game_map, players, realtime, random_seed=None, disable_fog=None):
         assert isinstance(realtime, bool)
-        req = sc_pb.RequestCreateGame(local_map=sc_pb.LocalMap(map_path=str(game_map.relative_path)), realtime=realtime)
+        req = sc_pb.RequestCreateGame(local_map=sc_pb.LocalMap(map_path=str(game_map.relative_path)), realtime=realtime, disable_fog=disable_fog)
         if random_seed is not None:
             req.random_seed = random_seed
 

--- a/sc2/main.py
+++ b/sc2/main.py
@@ -352,8 +352,8 @@ async def _play_replay(client, ai, realtime=False, player_id=0):
         iteration += 1
 
 
-async def _setup_host_game(server, map_settings, players, realtime, random_seed=None):
-    r = await server.create_game(map_settings, players, realtime, random_seed)
+async def _setup_host_game(server, map_settings, players, realtime, random_seed=None, disable_fog=None):
+    r = await server.create_game(map_settings, players, realtime, random_seed, disable_fog)
     if r.create_game.HasField("error"):
         err = f"Could not create game: {CreateGameError(r.create_game.error)}"
         if r.create_game.HasField("error_details"):
@@ -375,6 +375,7 @@ async def _host_game(
     rgb_render_config=None,
     random_seed=None,
     sc2_version=None,
+    disable_fog=None,
 ):
 
     assert players, "Can't create a game without players"
@@ -386,7 +387,7 @@ async def _host_game(
     ) as server:
         await server.ping()
 
-        client = await _setup_host_game(server, map_settings, players, realtime, random_seed)
+        client = await _setup_host_game(server, map_settings, players, realtime, random_seed, disable_fog)
         # Bot can decide if it wants to launch with 'raw_affects_selection=True'
         if not isinstance(players[0], Human) and getattr(players[0].ai, "raw_affects_selection", None) is not None:
             client.raw_affects_selection = players[0].ai.raw_affects_selection
@@ -494,7 +495,7 @@ def get_replay_version(replay_path):
 
 def run_game(map_settings, players, **kwargs):
     if sum(isinstance(p, (Human, Bot)) for p in players) > 1:
-        host_only_args = ["save_replay_as", "rgb_render_config", "random_seed", "sc2_version"]
+        host_only_args = ["save_replay_as", "rgb_render_config", "random_seed", "sc2_version", "disable_fog"]
         join_kwargs = {k: v for k, v in kwargs.items() if k not in host_only_args}
 
         portconfig = Portconfig()


### PR DESCRIPTION
This allows fog of war to be disabled for a game, this is useful for testing ML algorithms since it removes the complexity of hidden information