### PR TITLE
Add warning (once) when wrong target was given for a specific ability

### DIFF
--- a/sc2/constants.py
+++ b/sc2/constants.py
@@ -560,3 +560,10 @@ DAMAGE_BONUS_PER_UPGRADE: Dict[int, UnitTypeId] = {
     UnitTypeId.CORRUPTOR: {TargetType.Air.value: {IS_MASSIVE: 1}},
     UnitTypeId.BROODLORD: {TargetType.Ground.value: {None: 2}},
 }
+TARGET_HELPER = {
+    1: "no target",
+    2: "Point2",
+    3: "Unit",
+    4: "Point2 or Unit",
+    5: "Point2 or no target",
+}

--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -1429,19 +1429,19 @@ class Unit:
             return UnitCommand(ability, self, target=target, queue=queue)
         expected_target: int = self._bot_object.game_data.abilities[ability.value]._proto.target
         # 1: None, 2: Point, 3: Unit, 4: PointOrUnit, 5: PointOrNone
-        if target is None and expected_target not in [1, 5]:
+        if target is None and expected_target not in {1, 5}:
             warnings.warn(
                 f"{self} got {ability} with no target but expected {TARGET_HELPER[expected_target]}",
                 RuntimeWarning,
                 stacklevel=2,
             )
-        elif isinstance(target, Point2) and expected_target not in [2, 4, 5]:
+        elif isinstance(target, Point2) and expected_target not in {2, 4, 5}:
             warnings.warn(
                 f"{self} got {ability} with Point2 as target but expected {TARGET_HELPER[expected_target]}",
                 RuntimeWarning,
                 stacklevel=2,
             )
-        elif isinstance(target, Unit) and expected_target not in [3, 4]:
+        elif isinstance(target, Unit) and expected_target not in {3, 4}:
             warnings.warn(
                 f"{self} got {ability} with Unit as target but expected {TARGET_HELPER[expected_target]}",
                 RuntimeWarning,

--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -46,6 +46,7 @@ from .constants import (
     OFF_CREEP_SPEED_UPGRADE_DICT,
     OFF_CREEP_SPEED_INCREASE_DICT,
     SPEED_ALTERING_BUFFS,
+    TARGET_HELPER,
 )
 from .data import (
     Alliance,
@@ -1416,8 +1417,8 @@ class Unit:
 
     def __call__(
         self,
-        ability,
-        target=None,
+        ability: AbilityId,
+        target: Optional[Union[Point2, Unit]] = None,
         queue: bool = False,
         subtract_cost: bool = False,
         subtract_supply: bool = False,
@@ -1426,6 +1427,26 @@ class Unit:
         """ Deprecated: Stop using self.do() - This may be removed in the future. """
         if self._bot_object.unit_command_uses_self_do:
             return UnitCommand(ability, self, target=target, queue=queue)
+        expected_target: int = self._bot_object.game_data.abilities[ability.value]._proto.target
+        # 1: None, 2: Point, 3: Unit, 4: PointOrUnit, 5: PointOrNone
+        if target is None and expected_target not in [1, 5]:
+            warnings.warn(
+                f"{self} got {ability} with no target but expected {TARGET_HELPER[expected_target]}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        elif isinstance(target, Point2) and expected_target not in [2, 4, 5]:
+            warnings.warn(
+                f"{self} got {ability} with Point2 as target but expected {TARGET_HELPER[expected_target]}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        elif isinstance(target, Unit) and expected_target not in [3, 4]:
+            warnings.warn(
+                f"{self} got {ability} with Unit as target but expected {TARGET_HELPER[expected_target]}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         return self._bot_object.do(
             UnitCommand(ability, self, target=target, queue=queue),
             subtract_cost=subtract_cost,

--- a/test/damagetest_bot.py
+++ b/test/damagetest_bot.py
@@ -87,7 +87,7 @@ class TestBot(sc2.BotAI):
 
     # Create a lot of units and check if their damage calculation is correct based on Unit.calculate_damage_vs_target()
     async def test_botai_actions1001(self):
-        upgrade_levels = [0, 1]
+        upgrade_levels = {0, 1}
         attacker_units = [
             #
             # Protoss


### PR DESCRIPTION
E.g. Unit instead of expected Point2 as target for ravager bile