### PR TITLE
Fixed links to aiarena.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Extract these maps into their respective *subdirectories* in the SC2 maps direct
 e.g. `install-dir/Maps/Ladder2017Season1/`
 
 #### Bot ladder maps
-Maps that are run on the [SC2 AI Ladder](http://sc2ai.net/) and [SC2 AI Arena](https://ai-arena.net/) can be downloaded [from the sc2ai wiki](http://wiki.sc2ai.net/Ladder_Maps) and [the ai-arena wiki](https://ai-arena.net/wiki/bot-development/getting-started/#wiki-toc-maps).   
+Maps that are run on the [SC2 AI Ladder](http://sc2ai.net/) and [SC2 AI Arena](https://aiarena.net/) can be downloaded [from the sc2ai wiki](http://wiki.sc2ai.net/Ladder_Maps) and [the ai-arena wiki](https://aiarena.net/wiki/bot-development/getting-started/#wiki-toc-maps).   
 **Extract these maps into the *root* of the SC2 maps directory** (otherwise ladder replays won't work).  
 e.g. `install-dir/Maps/AcropolisLE.SC2Map`
 


### PR DESCRIPTION
I noticed that the current links for `aiarena.net` are incorrect, just thought I'd fix that.