### PR TITLE
Add support for running bots from WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ SC2PATH=/home/burny/Games/battlenet/drive_c/Program Files (x86)/StarCraft II/
 
 #### WSL
 
-WSL1 should not require any configuration. You may be asked to allow Python through your firewall.
+WSL version 1 should not require any configuration. You may be asked to allow Python through your firewall.
 
-When running WSL you need to supply the following environment variables so that your bot can connect:
+When running WSL version 2 you need to supply the following environment variables so that your bot can connect:
 
 ```sh
 SC2CLIENTHOST=<your windows IP>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ After installing the library, a StarCraft II executable, and some maps, you're r
 python3 examples/protoss/cannon_rush.py
 ```
 
+#### WINE and Lutris
+
 If you installed StarCraft II on Linux with Wine or Lutris, set the following environment variables (either globally or within your development environment, e.g. Pycharm: `Run -> Edit Configurations -> Environment Variables`):
 
 ```sh
@@ -64,6 +66,19 @@ WINE=usr/bin/wine
 # Default Lutris StarCraftII Installation path:
 SC2PATH=/home/burny/Games/battlenet/drive_c/Program Files (x86)/StarCraft II/
 ```
+
+#### WSL
+
+To run from a WSL1 instance, set `SC2PF=WSL1`. You may be asked to allow Python through your firewall.
+
+To run from a WSL2 instance, set `SC2PF=WSL2`. You also must supply
+
+```sh
+SC2CLIENTHOST=<your windows IP>
+SC2SERVERHOST=0.0.0.0
+```
+
+You can find your Windows IP using `ipconfig /all` from `PowerShell.exe` or `CMD.exe`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ SC2PATH=/home/burny/Games/battlenet/drive_c/Program Files (x86)/StarCraft II/
 
 #### WSL
 
-To run from a WSL1 instance, set `SC2PF=WSL1`. You may be asked to allow Python through your firewall.
+WSL1 should not require any configuration. You may be asked to allow Python through your firewall.
 
-To run from a WSL2 instance, set `SC2PF=WSL2`. You also must supply
+When running WSL you need to supply the following environment variables so that your bot can connect:
 
 ```sh
 SC2CLIENTHOST=<your windows IP>

--- a/sc2/paths.py
+++ b/sc2/paths.py
@@ -44,7 +44,13 @@ CWD = {
     "WineLinux": "Support64"
 }
 
-PF = os.environ.get("SC2PF", platform.system())
+def platform_detect():
+    pf = os.environ.get("SC2PF", platform.system())
+    if pf == "Linux":
+        return wsl.detect() or pf
+    return pf
+
+PF = platform_detect()
 
 def get_home():
     """Get home directory of user, using Windows home directory for WSL."""

--- a/sc2/paths.py
+++ b/sc2/paths.py
@@ -8,6 +8,8 @@ from loguru import logger
 
 BASEDIR = {
     "Windows": "C:/Program Files (x86)/StarCraft II",
+    "WSL1": "/mnt/c/Program Files (x86)/StarCraft II",
+    "WSL2": "/mnt/c/Program Files (x86)/StarCraft II",
     "Darwin": "/Applications/StarCraft II",
     "Linux": "~/StarCraftII",
     "WineLinux": "~/.wine/drive_c/Program Files (x86)/StarCraft II",
@@ -15,6 +17,8 @@ BASEDIR = {
 
 USERPATH = {
     "Windows": "\\Documents\\StarCraft II\\ExecuteInfo.txt",
+    "WSL1": "/Documents/StarCraft II/ExecuteInfo.txt",
+    "WSL2": "/Documents/StarCraft II/ExecuteInfo.txt",
     "Darwin": "/Library/Application Support/Blizzard/StarCraft II/ExecuteInfo.txt",
     "Linux": None,
     "WineLinux": None,
@@ -22,12 +26,21 @@ USERPATH = {
 
 BINPATH = {
     "Windows": "SC2_x64.exe",
+    "WSL1": "SC2_x64.exe",
+    "WSL2": "SC2_x64.exe",
     "Darwin": "SC2.app/Contents/MacOS/SC2",
     "Linux": "SC2_x64",
     "WineLinux": "SC2_x64.exe",
 }
 
-CWD = {"Windows": "Support64", "Darwin": None, "Linux": None, "WineLinux": "Support64"}
+CWD = {
+    "Windows": "Support64",
+    "WSL1": "Support64",
+    "WSL2": "Support64",
+    "Darwin": None,
+    "Linux": None,
+    "WineLinux": "Support64"
+}
 
 PF = os.environ.get("SC2PF", platform.system())
 

--- a/sc2/sc2process.py
+++ b/sc2/sc2process.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import os.path
 import shutil
 import signal
@@ -56,7 +57,7 @@ class SC2Process:
 
     def __init__(
         self,
-        host: str = "127.0.0.1",
+        host: Optional[str] = None,
         port: Optional[int] = None,
         fullscreen: bool = False,
         resolution: Optional[Union[List[int], Tuple[int, int]]] = None,
@@ -66,7 +67,7 @@ class SC2Process:
         base_build: str = None,
         data_hash: str = None,
     ) -> None:
-        assert isinstance(host, str)
+        assert isinstance(host, str) or host is None
         assert isinstance(port, int) or port is None
 
         self._render = render
@@ -78,7 +79,10 @@ class SC2Process:
             if placement and len(placement) == 2:
                 self._arguments["-windowx"] = str(placement[0])
                 self._arguments["-windowy"] = str(placement[1])
-        self._host = host
+
+        self._host = host or os.environ.get("SC2CLIENTHOST", "127.0.0.1")
+        self._serverhost = os.environ.get("SC2SERVERHOST", self._host)
+
         if port is None:
             self._port = portpicker.pick_unused_port()
         else:
@@ -145,7 +149,7 @@ class SC2Process:
         args = paths.get_runner_args(Paths.CWD) + [
             executable,
             "-listen",
-            self._host,
+            self._serverhost,
             "-port",
             str(self._port),
             "-dataDir",

--- a/sc2/wsl.py
+++ b/sc2/wsl.py
@@ -1,0 +1,19 @@
+import subprocess
+import re
+from pathlib import Path, PureWindowsPath
+
+## This file is used for compatibility with WSL and shouldn't need to be
+## accessed directly by any bot clients
+
+def win_path_to_wsl_path(path):
+    """Convert a windows-style path to a WSL path"""
+    # Substitute C:/ or equivalent with c/ or equivalent and prepend /mnt
+    return Path('/mnt') / PureWindowsPath(re.sub('^([A-Z]):', lambda m: m.group(1).lower(), path))
+
+def get_wsl_home():
+    """Get home directory of from Windows, even if run in WSL"""
+    proc = subprocess.run(['powershell.exe','-Command','Write-Host -NoNewLine $HOME'], capture_output = True)
+
+    if proc.returncode != 0: return None
+
+    return win_path_to_wsl_path(proc.stdout.decode('utf-8'))

--- a/sc2/wsl.py
+++ b/sc2/wsl.py
@@ -6,9 +6,12 @@ from pathlib import Path, PureWindowsPath
 ## accessed directly by any bot clients
 
 def win_path_to_wsl_path(path):
-    """Convert a windows-style path to a WSL path"""
-    # Substitute C:/ or equivalent with c/ or equivalent and prepend /mnt
+    """Convert a path like C:\\foo to /mnt/c/foo"""
     return Path('/mnt') / PureWindowsPath(re.sub('^([A-Z]):', lambda m: m.group(1).lower(), path))
+
+def wsl_path_to_win_path(path):
+    """Convert a path like /mnt/c/foo to C:\\foo"""
+    return PureWindowsPath(re.sub('^/mnt/([a-z])', lambda m: m.group(1).upper() + ":", path))
 
 def get_wsl_home():
     """Get home directory of from Windows, even if run in WSL"""
@@ -17,3 +20,39 @@ def get_wsl_home():
     if proc.returncode != 0: return None
 
     return win_path_to_wsl_path(proc.stdout.decode('utf-8'))
+
+RUN_SCRIPT = """$proc = Start-Process -NoNewWindow -PassThru "%s" "%s"
+if ($proc) {
+    Write-Host $proc.id
+    exit $proc.ExitCode
+} else {
+    exit 1
+}"""
+
+def run(popen_args, sc2_cwd):
+    """Run SC2 in Windows and get the pid so that it can be killed later."""
+    path = wsl_path_to_win_path(popen_args[0])
+    args = " ".join(popen_args[1:])
+
+    return subprocess.Popen(
+        ["powershell.exe", "-Command", RUN_SCRIPT % (path, args)],
+        cwd = sc2_cwd,
+        stdout = subprocess.PIPE,
+        universal_newlines = True,
+        bufsize = 1
+    )
+
+def kill(wsl_process):
+    """Needed to kill a process started with WSL. Returns true if killed successfully."""
+    # HACK: subprocess and WSL1 appear to have a nasty interaction where
+    # any streams are never closed and the process is never considered killed,
+    # despite having an exit code (this works on WSL2 as well, but isn't
+    # necessary). As a result,
+    # 1: We need to read using readline (to make sure we block long enough to
+    #    get the exit code in the rare case where the user immediately hits ^C)
+    out = wsl_process.stdout.readline().rstrip()
+    # 2: We need to use __exit__, since kill() calls send_signal(), which thinks
+    #    the process has already exited!
+    wsl_process.__exit__(None, None, None)
+    proc = subprocess.run(["taskkill.exe", "-f", "-pid", out], capture_output = True)
+    return proc.returncode == 0 # Returns 128 on failure


### PR DESCRIPTION
This PR allows users to run bots from WSL1 and WSL2.

- WSL1 should work out-of-the-box.
- For WSL2, you also need to configure the client/server IP to work over LAN.

Suggestions welcome to clean this up a bit. I don't typically work in Python and had a bit of trouble deciding where to put the client/server host configuration since `sc2process` doesn't feel like a great place to do it but the code is written in such a way it's exceptionally hard to do it anywhere else.

Tested on Windows, WSL1, and WSL2.