### PR TITLE
Correct morph_cost for morphed units

### DIFF
--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -695,19 +695,8 @@ class BotAI(DistanceCalculation):
                 elif item_id == UnitTypeId.ARCHON:
                     return self.calculate_unit_value(UnitTypeId.ARCHON)
             unit_data = self._game_data.units[item_id.value]
-            # Cost of structure morphs is automatically correctly calculated by 'calculate_ability_cost'
-            cost = self._game_data.calculate_ability_cost(unit_data.creation_ability)
-            # Fix non-structure morph cost: check if is morph, then subtract the original cost
-            unit_supply_cost = unit_data._proto.food_required
-            if unit_supply_cost > 0 and item_id in UNIT_TRAINED_FROM and len(UNIT_TRAINED_FROM[item_id]) == 1:
-                for producer in UNIT_TRAINED_FROM[item_id]:  # type: UnitTypeId
-                    producer_unit_data = self.game_data.units[producer.value]
-                    if 0 < producer_unit_data._proto.food_required <= unit_supply_cost:
-                        if producer == UnitTypeId.ZERGLING:
-                            producer_cost = Cost(25, 0)
-                        else:
-                            producer_cost = self.game_data.calculate_ability_cost(producer_unit_data.creation_ability)
-                        cost = cost - producer_cost
+            # Cost of morphs is automatically correctly calculated by 'calculate_ability_cost'
+            return self._game_data.calculate_ability_cost(unit_data.creation_ability)
 
         elif isinstance(item_id, UpgradeId):
             cost = self._game_data.upgrades[item_id.value].cost

--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple, Union, TYPE_CHECKING
 
 from .constants import ZERGLING
 from .data import Attribute, Race
+from .dicts.unit_trained_from import UNIT_TRAINED_FROM
 from .ids.ability_id import AbilityId
 from .ids.unit_typeid import UnitTypeId
 from .unit_command import UnitCommand
@@ -238,6 +239,21 @@ class UnitTypeData:
     @property
     def morph_cost(self) -> Optional[Cost]:
         """ This returns 150 minerals for OrbitalCommand instead of 550 """
+        # Morphing units
+        supply_cost = self._proto.food_required
+        if supply_cost > 0 and self.id in UNIT_TRAINED_FROM and len(UNIT_TRAINED_FROM[self.id]) == 1:
+            for producer in UNIT_TRAINED_FROM[self.id]:  # type: UnitTypeId
+                producer_unit_data = self._game_data.units[producer.value]
+                if 0 < producer_unit_data._proto.food_required <= supply_cost:
+                    if producer == UnitTypeId.ZERGLING:
+                        producer_cost = Cost(25, 0)
+                    else:
+                        producer_cost = self._game_data.calculate_ability_cost(producer_unit_data.creation_ability)
+                    return Cost(
+                        self._proto.mineral_cost - producer_cost.minerals,
+                        self._proto.vespene_cost - producer_cost.vespene,
+                        self._proto.build_time,
+                    )
         # Fix for BARRACKSREACTOR which has tech alias [REACTOR] which has (0, 0) cost
         if self.tech_alias is None or self.tech_alias[0] in {UnitTypeId.TECHLAB, UnitTypeId.REACTOR}:
             return None

--- a/test/test_pickled_data.py
+++ b/test/test_pickled_data.py
@@ -377,12 +377,10 @@ def test_bot_ai():
     assert bot.calculate_cost(UnitTypeId.SPIRE) == Cost(200, 200)
     assert bot.calculate_cost(UnitTypeId.ARCHON) == bot.calculate_unit_value(UnitTypeId.ARCHON)
 
-    # The following are morph abilities that may need a fix
-    assert_cost(AbilityId.MORPHTOBROODLORD_BROODLORD, Cost(300, 250))
-    assert_cost(UnitTypeId.BROODLORD, Cost(300, 250))
-    assert_cost(AbilityId.MORPHTORAVAGER_RAVAGER, Cost(100, 100))
-    assert_cost(AbilityId.MORPHTOBROODLORD_BROODLORD, Cost(300, 250))
-    assert_cost(AbilityId.MORPHZERGLINGTOBANELING_BANELING, Cost(50, 25))
+    assert_cost(AbilityId.MORPHTOBROODLORD_BROODLORD, Cost(150, 150))
+    assert_cost(AbilityId.MORPHTORAVAGER_RAVAGER, Cost(25, 75))
+    assert_cost(AbilityId.MORPH_LURKER, Cost(50, 100))
+    assert_cost(AbilityId.MORPHZERGLINGTOBANELING_BANELING, Cost(25, 25))
 
     assert Cost(100, 50) == 2 * Cost(50, 25)
     assert Cost(100, 50) == Cost(50, 25) * 2


### PR DESCRIPTION
Move the logic from `calculate_cost` to `UnitTypeData.morph_cost`. This makes `game_data.calculate_ability_cost` (which is used by `bot_ai.do`) return the correct values for morph abilities.
