### PR TITLE
Fix for expansion locations bot_ai.py

### DIFF
--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -363,6 +363,10 @@ class BotAI(DistanceCalculation):
                     for resource in resources
                 )
             )
+            #Recast generator object 'possible_points' to list as no further changes are done. Skip processing of this loop if no 'possible_points' left.
+            possible_points = list(possible_points)
+            if len(possible_points) == 0:
+                continue
             # Choose best fitting point
             result: Point2 = min(
                 possible_points, key=lambda point: sum(point.distance_to(resource) for resource in resources)


### PR DESCRIPTION
function _find_expansion_locations generates group of locations: 'possible_points'.
Then this group is eliminated based on distance to closest resources.
In case none is left, later at line 367 min() function for distance fails as it has no arguments to compare.
Fix enables playing on wider variety of maps. (Like many maps for 3+ players where resource placement is not perfect.)