### PR TITLE
Add single unit unload example bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ class MyBot(sc2.BotAI):
         self.raw_affects_selection = True
 ```
 
+### `enable_feature_layer`
+Setting this to true allows interaction with the UI
+```python
+class MyBot(sc2.BotAI):
+    def __init__(self):
+        self.enable_feature_layer = True
+```
+
 ### `distance_calculation_method`
 The distance calculation method:
 - 0 for raw python

--- a/examples/protoss/single_unit_unload_test.py
+++ b/examples/protoss/single_unit_unload_test.py
@@ -1,7 +1,8 @@
 import sys, os
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
+sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
 
+from typing import Union
 from loguru import logger
 
 import sc2
@@ -17,15 +18,56 @@ from s2clientprotocol import ui_pb2 as ui_pb
 
 
 class SingleUnitUnloadBot(sc2.BotAI):
+    def __init__(self):
+        self.raw_affects_selection = True
+        self.enable_feature_layer = True
+
     async def on_start(self):
         self.client.game_step = 8
-        self.raw_affects_selection = True
         self.load_unit_types = {
             UnitTypeId.ZEALOT,
             UnitTypeId.STALKER,
             UnitTypeId.DARKTEMPLAR,
             UnitTypeId.HIGHTEMPLAR,
         }
+
+    async def unload_unit(self, transporter_unit: Unit, unload_unit: Union[int, Unit]):
+        assert isinstance(transporter_unit, Unit)
+        assert isinstance(unload_unit, (int, Unit))
+        assert hasattr(self, "raw_affects_selection") and self.raw_affects_selection is True
+        assert hasattr(self, "enable_feature_layer") and self.enable_feature_layer is True
+        if isinstance(unload_unit, Unit):
+            unload_unit_tag = unload_unit.tag
+        else:
+            unload_unit_tag = unload_unit
+
+        # TODO Change unit.py passengers to return a List[Unit] instead of Set[Unit] ? Then I don't have to loop over '._proto'
+        unload_unit_index = next(
+            (index for index, unit in enumerate(transporter_unit._proto.passengers) if unit.tag == unload_unit_tag),
+            None
+        )
+
+        if unload_unit_index is None:
+            logger.info(f"Unable to find unit {unload_unit} in transporter {transporter_unit}")
+            return
+
+        logger.info(f"Unloading unit at index: {unload_unit_index}")
+        await self.client._execute(
+            action=sc_pb.RequestAction(
+                actions=[
+                    sc_pb.Action(
+                        action_raw=raw_pb.ActionRaw(
+                            unit_command=raw_pb.ActionRawUnitCommand(ability_id=0, unit_tags=[transporter_unit.tag])
+                        )
+                    ),
+                    sc_pb.Action(
+                        action_ui=ui_pb.ActionUI(
+                            cargo_panel=ui_pb.ActionCargoPanelUnload(unit_index=unload_unit_index)
+                        )
+                    ),
+                ]
+            )
+        )
 
     async def on_step(self, iteration):
         # Spawn units
@@ -52,39 +94,19 @@ class SingleUnitUnloadBot(sc2.BotAI):
         await self._advance_steps(50)
         assert self.units(self.load_unit_types).amount == 0
         prism: Unit = self.units(UnitTypeId.WARPPRISM)[0]
-        zealot_index = next(
-            (
-                index for index, unit in enumerate(prism.passengers)
-                if unit.type_id == UnitTypeId.ZEALOT and unit.tag == my_zealot.tag
-            ), None
-        )
-
-        if zealot_index is not None:
-            logger.info(f"Unloading unit at index: {zealot_index}")
-            await self.client._execute(
-                action=sc_pb.RequestAction(
-                    actions=[
-                        sc_pb.Action(
-                            action_raw=raw_pb.ActionRaw(
-                                unit_command=raw_pb.ActionRawUnitCommand(ability_id=0, unit_tags=[prism.tag])
-                            )
-                        ),
-                        sc_pb.Action(
-                            action_ui=ui_pb.ActionUI(
-                                # this can't actually be reached if index hasn't been assigned a value
-                                cargo_panel=ui_pb.ActionCargoPanelUnload(unit_index=zealot_index)
-                            )
-                        ),
-                    ]
-                )
-            )
+        await self.unload_unit(prism, my_zealot)
+        # Also works:
+        # await self.unload_unit(prism, my_zealot.tag)
 
         await self._advance_steps(50)
         my_units = self.units(self.load_unit_types)
         assert my_units.amount == 1, f"{my_units}"
         my_zealots = self.units(UnitTypeId.ZEALOT)
         assert my_zealots.amount == 1, f"{my_zealots}"
-        assert my_zealots.amount[0].tag == my_zealot.tag
+        assert my_zealots[0].tag == my_zealot.tag
+
+        logger.info("Everything ran as expected. Terminating.")
+        await self.client.leave()
 
 
 def main():

--- a/examples/protoss/single_unit_unload_test.py
+++ b/examples/protoss/single_unit_unload_test.py
@@ -1,0 +1,101 @@
+import sys, os
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
+
+from loguru import logger
+
+import sc2
+from sc2 import Race, Difficulty
+from sc2.ids.unit_typeid import UnitTypeId
+from sc2.player import Bot, Computer
+from sc2.unit import Unit
+from sc2.units import Units
+
+from s2clientprotocol import raw_pb2 as raw_pb
+from s2clientprotocol import sc2api_pb2 as sc_pb
+from s2clientprotocol import ui_pb2 as ui_pb
+
+
+class SingleUnitUnloadBot(sc2.BotAI):
+    async def on_start(self):
+        self.client.game_step = 8
+        self.raw_affects_selection = True
+        self.load_unit_types = {
+            UnitTypeId.ZEALOT,
+            UnitTypeId.STALKER,
+            UnitTypeId.DARKTEMPLAR,
+            UnitTypeId.HIGHTEMPLAR,
+        }
+
+    async def on_step(self, iteration):
+        # Spawn units
+        logger.info(f"Spawning units")
+        await self.client.debug_create_unit(
+            [
+                [UnitTypeId.WARPPRISM, 1, self.game_info.map_center, 1],
+                [UnitTypeId.ZEALOT, 1, self.game_info.map_center, 1],
+                [UnitTypeId.STALKER, 1, self.game_info.map_center, 1],
+                [UnitTypeId.DARKTEMPLAR, 1, self.game_info.map_center, 1],
+                [UnitTypeId.HIGHTEMPLAR, 1, self.game_info.map_center, 1],
+            ]
+        )
+        # Load units into prism
+        await self._advance_steps(50)
+        prism = self.units(UnitTypeId.WARPPRISM)[0]
+        my_zealot = self.units(UnitTypeId.ZEALOT)[0]
+        my_units = self.units(self.load_unit_types)
+        logger.info(f"Loading units into prism: {my_units}")
+        for unit in my_units:
+            unit.smart(prism)
+
+        # Unload single unit - here: zealot
+        await self._advance_steps(50)
+        assert self.units(self.load_unit_types).amount == 0
+        prism: Unit = self.units(UnitTypeId.WARPPRISM)[0]
+        zealot_index = next(
+            (
+                index for index, unit in enumerate(prism.passengers)
+                if unit.type_id == UnitTypeId.ZEALOT and unit.tag == my_zealot.tag
+            ), None
+        )
+
+        if zealot_index is not None:
+            logger.info(f"Unloading unit at index: {zealot_index}")
+            await self.client._execute(
+                action=sc_pb.RequestAction(
+                    actions=[
+                        sc_pb.Action(
+                            action_raw=raw_pb.ActionRaw(
+                                unit_command=raw_pb.ActionRawUnitCommand(ability_id=0, unit_tags=[prism.tag])
+                            )
+                        ),
+                        sc_pb.Action(
+                            action_ui=ui_pb.ActionUI(
+                                # this can't actually be reached if index hasn't been assigned a value
+                                cargo_panel=ui_pb.ActionCargoPanelUnload(unit_index=zealot_index)
+                            )
+                        ),
+                    ]
+                )
+            )
+
+        await self._advance_steps(50)
+        my_units = self.units(self.load_unit_types)
+        assert my_units.amount == 1, f"{my_units}"
+        my_zealots = self.units(UnitTypeId.ZEALOT)
+        assert my_zealots.amount == 1, f"{my_zealots}"
+        assert my_zealots.amount[0].tag == my_zealot.tag
+
+
+def main():
+    sc2.run_game(
+        sc2.maps.get("2000AtmospheresAIE"),
+        [Bot(Race.Protoss, SingleUnitUnloadBot()),
+         Computer(Race.Terran, Difficulty.Medium)],
+        realtime=False,
+        save_replay_as="PvT.SC2Replay",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/zerg/expand_everywhere.py
+++ b/examples/zerg/expand_everywhere.py
@@ -3,7 +3,6 @@ from contextlib import suppress
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
 
-import numpy as np
 from sc2.position import Point2, Point3
 
 import sc2
@@ -76,7 +75,7 @@ class ExpandEverywhere(sc2.BotAI):
 
 def main():
     sc2.run_game(
-        sc2.maps.get("AcropolisLE"),
+        sc2.maps.get("2000AtmospheresAIE"),
         [Bot(Race.Zerg, ExpandEverywhere()), Computer(Race.Terran, Difficulty.Medium)],
         realtime=False,
         save_replay_as="ZvT.SC2Replay",

--- a/sc2/main.py
+++ b/sc2/main.py
@@ -472,8 +472,11 @@ async def _host_game(
 
         client = await _setup_host_game(server, map_settings, players, realtime, random_seed, disable_fog)
         # Bot can decide if it wants to launch with 'raw_affects_selection=True'
-        if not isinstance(players[0], Human) and getattr(players[0].ai, "raw_affects_selection", None) is not None:
+        if not isinstance(players[0], Human) and getattr(players[0].ai, "enable_feature_layer", None) is not None:
             client.raw_affects_selection = players[0].ai.raw_affects_selection
+        # And 'enable_feature_layer=True'
+        if not isinstance(players[0], Human) and getattr(players[0].ai, "enable_feature_layer", None) is not None:
+            client.enable_feature_layer = players[0].ai.enable_feature_layer
 
         try:
             result = await _play_game(
@@ -510,6 +513,8 @@ async def _host_game_aiter(
             client = await _setup_host_game(server, map_settings, players, realtime)
             if not isinstance(players[0], Human) and getattr(players[0].ai, "raw_affects_selection", None) is not None:
                 client.raw_affects_selection = players[0].ai.raw_affects_selection
+            if not isinstance(players[0], Human) and getattr(players[0].ai, "enable_feature_layer", None) is not None:
+                client.enable_feature_layer = players[0].ai.enable_feature_layer
 
             try:
                 result = await _play_game(players[0], client, realtime, portconfig, step_time_limit, game_time_limit)
@@ -548,6 +553,9 @@ async def _join_game(
         # Bot can decide if it wants to launch with 'raw_affects_selection=True'
         if not isinstance(players[1], Human) and getattr(players[1].ai, "raw_affects_selection", None) is not None:
             client.raw_affects_selection = players[1].ai.raw_affects_selection
+        # And 'enable_feature_layer=True'
+        if not isinstance(players[1], Human) and getattr(players[1].ai, "enable_feature_layer", None) is not None:
+            client.enable_feature_layer = players[1].ai.enable_feature_layer
 
         try:
             result = await _play_game(players[1], client, realtime, portconfig, step_time_limit, game_time_limit)


### PR DESCRIPTION
Goal of this PR: introduce individual unit unloading from transports, while allowing bot authors to decide if they want to enable this feature layer or not (there might be performance disadvantages)

TODO:
- [ ] Remove required unload index, instead find index from tag as described in https://github.com/BurnySc2/python-sc2/pull/155