### PR TITLE
examples imports fix

### DIFF
--- a/examples/bot_vs_bot.py
+++ b/examples/bot_vs_bot.py
@@ -1,13 +1,14 @@
+from sc2 import maps
+from sc2.data import Race
+from sc2.main import run_game
 from zerg.zerg_rush import ZergRushBot
 
-import sc2
-from sc2 import Race
 from sc2.player import Bot
 
 
 def main():
-    sc2.run_game(
-        sc2.maps.get("AcropolisLE"),
+    run_game(
+        maps.get("AcropolisLE"),
         [Bot(Race.Zerg, ZergRushBot()), Bot(Race.Zerg, ZergRushBot())],
         realtime=False,
         save_replay_as="Example.SC2Replay",

--- a/examples/competitive/bot.py
+++ b/examples/competitive/bot.py
@@ -1,7 +1,7 @@
-import sc2
+from sc2.bot_ai import BotAI
 
 
-class CompetitiveBot(sc2.BotAI):
+class CompetitiveBot(BotAI):
     async def on_start(self):
         print("Game started")
         # Do things here before the game starts

--- a/examples/observer_easy_vs_easy.py
+++ b/examples/observer_easy_vs_easy.py
@@ -1,12 +1,13 @@
-import sc2
 from examples.protoss.cannon_rush import CannonRushBot
-from sc2 import Difficulty, Race
+from sc2 import maps
+from sc2.data import Race, Difficulty
+from sc2.main import run_game
 from sc2.player import Bot, Computer
 
 
 def main():
-    sc2.run_game(
-        sc2.maps.get("Abyssal Reef LE"),
+    run_game(
+        maps.get("Abyssal Reef LE"),
         [Bot(Race.Protoss, CannonRushBot()),
          Computer(Race.Protoss, Difficulty.Medium)],
         realtime=True,

--- a/examples/play_tvz.py
+++ b/examples/play_tvz.py
@@ -1,11 +1,12 @@
-import sc2
 from examples.zerg.zerg_rush import ZergRushBot
-from sc2 import Race
+from sc2 import maps
+from sc2.data import Race
+from sc2.main import run_game
 from sc2.player import Bot, Human
 
 
 def main():
-    sc2.run_game(sc2.maps.get("Abyssal Reef LE"), [Human(Race.Terran), Bot(Race.Zerg, ZergRushBot())], realtime=True)
+    run_game(maps.get("Abyssal Reef LE"), [Human(Race.Terran), Bot(Race.Zerg, ZergRushBot())], realtime=True)
 
 
 if __name__ == "__main__":

--- a/examples/worker_rush.py
+++ b/examples/worker_rush.py
@@ -1,9 +1,11 @@
-import sc2
-from sc2 import Difficulty, Race, maps, run_game
+from sc2 import maps
+from sc2.bot_ai import BotAI
+from sc2.data import Race, Difficulty
+from sc2.main import run_game
 from sc2.player import Bot, Computer
 
 
-class WorkerRushBot(sc2.BotAI):
+class WorkerRushBot(BotAI):
     async def on_step(self, iteration):
         if iteration == 0:
             for worker in self.workers:


### PR DESCRIPTION
not sure why and if that is expected in Py but after forking repo, opening it in PyCharm got squigglies around few imports here and there, tried to fix them so examples are runnable out of the box