### PR TITLE
Make _prepare_step async and add Unit.abilities

### DIFF
--- a/sc2/bot_ai_internal.py
+++ b/sc2/bot_ai_internal.py
@@ -21,6 +21,7 @@ from sc2.constants import (
     ALL_GAS,
     IS_PLACEHOLDER,
     TERRAN_STRUCTURES_REQUIRE_SCV,
+    WORKER_TYPES,
     FakeEffectID,
     abilityid_to_unittypeid,
     geyser_ids,
@@ -110,6 +111,7 @@ class BotAIInternal(ABC):
         self._enemy_units_previous_map: Dict[int, Unit] = {}
         self._enemy_structures_previous_map: Dict[int, Unit] = {}
         self._all_units_previous_map: Dict[int, Unit] = {}
+        self._unit_abilities: Dict[int, Set[AbilityId]] = {}
         self._previous_upgrades: Set[UpgradeId] = set()
         self._expansion_positions_list: List[Point2] = []
         self._resource_location_to_expansion_position_dict: Dict[Point2, Point2] = {}
@@ -469,7 +471,7 @@ class BotAIInternal(ABC):
         self._time_before_step: float = time.perf_counter()
 
     @final
-    def _prepare_step(self, state, proto_game_info):
+    async def _prepare_step(self, state, proto_game_info):
         """
         :param state:
         :param proto_game_info:
@@ -505,6 +507,12 @@ class BotAIInternal(ABC):
 
         self.idle_worker_count: int = state.common.idle_worker_count
         self.army_count: int = state.common.army_count
+
+        self._unit_abilities = await self.client.query_available_abilities_with_tag(
+            self.all_own_units,
+            ignore_resource_requirements=True,
+        )
+
         self._time_before_step: float = time.perf_counter()
 
         if self.enemy_race == Race.Random and self.all_enemy_units:
@@ -533,8 +541,6 @@ class BotAIInternal(ABC):
         self.placeholders: Units = Units([], self)
         self.techlab_tags: Set[int] = set()
         self.reactor_tags: Set[int] = set()
-
-        worker_types: Set[UnitTypeId] = {UnitTypeId.DRONE, UnitTypeId.DRONEBURROWED, UnitTypeId.SCV, UnitTypeId.PROBE}
 
         index: int = 0
         for unit in self.state.observation_raw.units:
@@ -596,7 +602,7 @@ class BotAIInternal(ABC):
                             self.reactor_tags.add(unit_obj.tag)
                     else:
                         self.units.append(unit_obj)
-                        if unit_id in worker_types:
+                        if unit_id in WORKER_TYPES:
                             self.workers.append(unit_obj)
                         elif unit_id == UnitTypeId.LARVA:
                             self.larva.append(unit_obj)
@@ -646,7 +652,7 @@ class BotAIInternal(ABC):
         state = await self.client.observation()
         gs = GameState(state.observation)
         proto_game_info = await self.client._execute(game_info=sc_pb.RequestGameInfo())
-        self._prepare_step(gs, proto_game_info)
+        await self._prepare_step(gs, proto_game_info)
         await self.issue_events()
 
     @final

--- a/sc2/constants.py
+++ b/sc2/constants.py
@@ -7,6 +7,8 @@ from sc2.ids.buff_id import BuffId
 from sc2.ids.unit_typeid import UnitTypeId
 from sc2.ids.upgrade_id import UpgradeId
 
+WORKER_TYPES: Set[UnitTypeId] = {UnitTypeId.DRONE, UnitTypeId.DRONEBURROWED, UnitTypeId.SCV, UnitTypeId.PROBE}
+
 mineral_ids: Set[int] = {
     UnitTypeId.RICHMINERALFIELD.value,
     UnitTypeId.RICHMINERALFIELD750.value,

--- a/sc2/main.py
+++ b/sc2/main.py
@@ -130,7 +130,7 @@ async def _play_game_ai(
         gs = GameState(state.observation)
         proto_game_info = await client._execute(game_info=sc_pb.RequestGameInfo())
         try:
-            ai._prepare_step(gs, proto_game_info)
+            await ai._prepare_step(gs, proto_game_info)
             await ai.on_before_start()
             ai._prepare_first_step()
             await ai.on_start()
@@ -191,7 +191,7 @@ async def _play_game_ai(
             await ai.on_end(Result.Tie)
             return Result.Tie
         proto_game_info = await client._execute(game_info=sc_pb.RequestGameInfo())
-        ai._prepare_step(gs, proto_game_info)
+        await ai._prepare_step(gs, proto_game_info)
 
         await run_bot_iteration(iteration)  # Main bot loop
 
@@ -252,7 +252,7 @@ async def _play_replay(client, ai, realtime=False, player_id=0):
         return client._game_result[player_id]
     gs = GameState(state.observation)
     proto_game_info = await client._execute(game_info=sc_pb.RequestGameInfo())
-    ai._prepare_step(gs, proto_game_info)
+    await ai._prepare_step(gs, proto_game_info)
     ai._prepare_first_step()
     try:
         await ai.on_start()
@@ -283,7 +283,7 @@ async def _play_replay(client, ai, realtime=False, player_id=0):
             logger.debug(f"Score: {gs.score.score}")
 
             proto_game_info = await client._execute(game_info=sc_pb.RequestGameInfo())
-            ai._prepare_step(gs, proto_game_info)
+            await ai._prepare_step(gs, proto_game_info)
 
         logger.debug(f"Running AI step, it={iteration} {gs.game_loop * 0.725 * (1 / 16):.2f}s")
 

--- a/test/autotest_bot.py
+++ b/test/autotest_bot.py
@@ -109,6 +109,39 @@ class TestBot(BotAI):
         for location in self.enemy_start_locations:
             assert location in self.expansion_locations_list
 
+        # Test if units and structures have expected abilities
+        standard_scv_abilities = {
+            AbilityId.ATTACK_ATTACK,
+            AbilityId.EFFECT_REPAIR_SCV,
+            AbilityId.EFFECT_SPRAY_TERRAN,
+            AbilityId.HARVEST_GATHER_SCV,
+            AbilityId.HOLDPOSITION_HOLD,
+            AbilityId.MOVE_MOVE,
+            AbilityId.PATROL_PATROL,
+            AbilityId.SMART,
+            AbilityId.STOP_STOP,
+            AbilityId.TERRANBUILD_COMMANDCENTER,
+            AbilityId.TERRANBUILD_ENGINEERINGBAY,
+            AbilityId.TERRANBUILD_REFINERY,
+            AbilityId.TERRANBUILD_SUPPLYDEPOT,
+        }
+        for scv in self.units:
+            assert isinstance(scv.abilities, set)
+            if scv.is_carrying_minerals:
+                assert scv.abilities == standard_scv_abilities | {AbilityId.HARVEST_RETURN_SCV}
+            else:
+                assert scv.abilities == standard_scv_abilities
+
+        for cc in self.townhalls:
+            assert isinstance(cc.abilities, set)
+            assert cc.abilities == {
+                AbilityId.COMMANDCENTERTRAIN_SCV,
+                AbilityId.LIFT_COMMANDCENTER,
+                AbilityId.LOADALL_COMMANDCENTER,
+                AbilityId.RALLY_COMMANDCENTER,
+                AbilityId.SMART,
+            }
+
         self.tests_done_by_name.add("test_botai_properties")
 
     # Test BotAI functions
@@ -438,8 +471,6 @@ class TestBot(BotAI):
 
     # Test if structures_without_construction_SCVs works after killing the scv
     async def test_botai_actions12(self):
-        map_center: Point2 = self.game_info.map_center
-
         # Wait till can afford depot
         while not self.can_afford(UnitTypeId.SUPPLYDEPOT):
             await self.client.debug_all_resources()

--- a/test/benchmark_bot_ai_init.py
+++ b/test/benchmark_bot_ai_init.py
@@ -2,12 +2,12 @@ from test.test_pickled_data import MAPS, build_bot_object_from_pickle_data, load
 from typing import Any, List, Tuple
 
 
-def _test_run_bot_ai_init_on_all_maps(pickle_data: List[Tuple[Any, Any, Any]]):
+async def _test_run_bot_ai_init_on_all_maps(pickle_data: List[Tuple[Any, Any, Any]]):
     for data in pickle_data:
-        build_bot_object_from_pickle_data(*data)
+        await build_bot_object_from_pickle_data(*data)
 
 
-def test_bench_bot_ai_init(benchmark):
+async def test_bench_bot_ai_init(benchmark):
     # Load pickle files outside of benchmark
     map_pickle_data: List[Tuple[Any, Any, Any]] = [load_map_pickle_data(path) for path in MAPS]
     _result = benchmark(_test_run_bot_ai_init_on_all_maps, map_pickle_data)

--- a/test/benchmark_bot_ai_init.py
+++ b/test/benchmark_bot_ai_init.py
@@ -1,12 +1,15 @@
 from test.test_pickled_data import MAPS, build_bot_object_from_pickle_data, load_map_pickle_data
 from typing import Any, List, Tuple
 
+import pytest
+
 
 async def _test_run_bot_ai_init_on_all_maps(pickle_data: List[Tuple[Any, Any, Any]]):
     for data in pickle_data:
         await build_bot_object_from_pickle_data(*data)
 
 
+@pytest.mark.asyncio
 async def test_bench_bot_ai_init(benchmark):
     # Load pickle files outside of benchmark
     map_pickle_data: List[Tuple[Any, Any, Any]] = [load_map_pickle_data(path) for path in MAPS]

--- a/test/benchmark_prepare_units.py
+++ b/test/benchmark_prepare_units.py
@@ -1,16 +1,19 @@
 from test.test_pickled_data import MAPS, get_map_specific_bot
 from typing import TYPE_CHECKING, List
 
+import pytest
+
 if TYPE_CHECKING:
     from sc2.bot_ai import BotAI
 
 
-def _run_prepare_units(bot_objects: List["BotAI"]):
+async def _run_prepare_units(bot_objects: List["BotAI"]):
     for bot_object in bot_objects:
-        bot_object._prepare_units()
+        await bot_object._prepare_units()
 
 
-def test_bench_prepare_units(benchmark):
+@pytest.mark.asyncio
+async def test_bench_prepare_units(benchmark):
     bot_objects = [get_map_specific_bot(map_) for map_ in MAPS]
     _result = benchmark(_run_prepare_units, bot_objects)
 

--- a/test/test_pickled_ramp.py
+++ b/test/test_pickled_ramp.py
@@ -12,8 +12,10 @@ import time
 from pathlib import Path
 from test.test_pickled_data import MAPS, get_map_specific_bot
 
+import pytest
 from loguru import logger
 
+from sc2.bot_ai import BotAI
 from sc2.game_info import Ramp
 from sc2.position import Point2
 from sc2.unit import Unit
@@ -36,8 +38,9 @@ class TestClass:
     # Load all pickle files and convert them into bot objects from raw data (game_data, game_info, game_state)
     scenarios = [(map_path.name, {"map_path": map_path}) for map_path in MAPS]
 
-    def test_main_base_ramp(self, map_path: Path):
-        bot = get_map_specific_bot(map_path)
+    @pytest.mark.asyncio
+    async def test_main_base_ramp(self, map_path: Path):
+        bot: BotAI = await get_map_specific_bot(map_path)
         bot.game_info.map_ramps, bot.game_info.vision_blockers = bot.game_info._find_ramps_and_vision_blockers()
 
         # Test if main ramp works for all spawns
@@ -85,8 +88,9 @@ class TestClass:
                 assert ramp.protoss_wall_buildings == frozenset()
                 assert ramp.protoss_wall_warpin is None
 
-    def test_bot_ai(self, map_path: Path):
-        bot = get_map_specific_bot(map_path)
+    @pytest.mark.asyncio
+    async def test_bot_ai(self, map_path: Path):
+        bot: BotAI = await get_map_specific_bot(map_path)
 
         # Recalculate and time expansion locations
         t0 = time.perf_counter()


### PR DESCRIPTION
Fixes https://github.com/BurnySc2/python-sc2/issues/157

This PR adds the `Unit.abilities` property which returns a set of AbilityId for all own units. Returns an empty set and a warning for neutral and enemy units.
This is useful so you don't have to handle querying abilities yourself, to check if tech requirement is met or if an ability is on cooldown (e.g. blink). However this sends one query to the API on each iteration before `on_step` is called.