### PR TITLE
Start locations position rounding

### DIFF
--- a/sc2/game_info.py
+++ b/sc2/game_info.py
@@ -231,8 +231,9 @@ class GameInfo:
             p.player_id: p.race_actual or p.race_requested
             for p in self._proto.player_info
         }
-        self.start_locations: List[Point2] = [Point2.from_proto(sl) for sl in self._proto.start_raw.start_locations]
-        self.start_locations = [Point2((round(x, 1), round(y, 1)))  for x, y in self.start_locations]            
+        self.start_locations: List[Point2] = [
+            Point2.from_proto(sl).round(decimals=1) for sl in self._proto.start_raw.start_locations
+        ]
         self.player_start_location: Point2 = None  # Filled later by BotAI._prepare_first_step
 
     def _find_ramps_and_vision_blockers(self) -> Tuple[List[Ramp], FrozenSet[Point2]]:

--- a/sc2/game_info.py
+++ b/sc2/game_info.py
@@ -232,6 +232,7 @@ class GameInfo:
             for p in self._proto.player_info
         }
         self.start_locations: List[Point2] = [Point2.from_proto(sl) for sl in self._proto.start_raw.start_locations]
+        self.start_locations = [Point2((round(x, 1), round(y, 1)))  for x, y in self.start_locations]            
         self.player_start_location: Point2 = None  # Filled later by BotAI._prepare_first_step
 
     def _find_ramps_and_vision_blockers(self) -> Tuple[List[Ramp], FrozenSet[Point2]]:

--- a/sc2/position.py
+++ b/sc2/position.py
@@ -190,10 +190,14 @@ class Point2(Pointlike):
     def to3(self) -> Point3:
         return Point3((*self, 0))
 
-    def offset(self, p: Point2):
+    def round(self, decimals: int) -> Point2:
+        """Rounds each number in the tuple to the amount of given decimals."""
+        return Point2((round(self[0], decimals), round(self[1], decimals)))
+
+    def offset(self, p: Point2) -> Point2:
         return Point2((self[0] + p[0], self[1] + p[1]))
 
-    def random_on_distance(self, distance):
+    def random_on_distance(self, distance) -> Point2:
         if isinstance(distance, (tuple, list)):  # interval
             distance = distance[0] + random.random() * (distance[1] - distance[0])
 


### PR DESCRIPTION
Start locations position rounding, they are sligthy offset in some maps, like in InsideAndOutAIE (33.499755859375, 30.5) instead of (33.5, 30.5)