### PR TITLE
Codecov version in project version has been yoinked.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ scipy = "^1.7.1"
 protobuf = "<4.0.0"
 
 [tool.poetry.dev-dependencies]
-codecov = "^2.1.12"
+codecov = "^2.1.13"
 coverage = "^7.0"
 hypothesis = "^6.23.1"
 matplotlib = "^3.4.3"


### PR DESCRIPTION
Codecov package from poetry is no longer installable as it's been removed from pypi.
A final version was pushed for compatibility's sake. This change bumps up the version to an installable package.
https://about.codecov.io/blog/message-regarding-the-pypi-package/