### PR TITLE
Makes unit.tag be @cached_property

### DIFF
--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -154,7 +154,7 @@ class Unit:
         """Returns the race of the unit"""
         return Race(self._type_data._proto.race)
 
-    @property
+    @cached_property
     def tag(self) -> int:
         """Returns the unique tag of the unit."""
         return self._proto.tag


### PR DESCRIPTION
**This commit is an optimization.**
I ran cProfiler on an example bot of sorts and noticed that `unit.tag` is one of the worst offenders.
I made it a cached property instead and it cleared itself up.

This is due to heavy dictionary lookups in practice.
Rasper has been manually caching tag in his framework for some time, using custom overrides and agrees this change is safe.
So, nowhere in the library or in the wild do we manually change a unit's identifier once set. 

I firmly believe this can go upstream.

Before:  
<img width="1019" alt="before" src="https://github.com/user-attachments/assets/db7ec09e-9604-4fbb-a832-2abae40e6547" />


After:  
<img width="1028" alt="after" src="https://github.com/user-attachments/assets/3784aebf-e813-4404-9126-17d0921fea96" />
