### PR TITLE
Fix find_placement function using addon_place=True

### DIFF
--- a/sc2/bot_ai.py
+++ b/sc2/bot_ai.py
@@ -694,7 +694,7 @@ class BotAI(BotAIInternal):
             building = self.game_data.units[building.value].creation_ability.id
 
         if await self.can_place_single(building, near) and (
-            not addon_place or await self.can_place_single(UnitTypeId.SUPPLYDEPOT, near.offset((2.5, -0.5)))
+            not addon_place or await self.can_place_single(AbilityId.TERRANBUILD_SUPPLYDEPOT, near.offset((2.5, -0.5)))
         ):
             return near
 
@@ -718,7 +718,7 @@ class BotAI(BotAIInternal):
             if addon_place:
                 # Filter remaining positions if addon can be placed
                 res = await self.client._query_building_placement_fast(
-                    AbilityId.TERRANBUILDDROP_SUPPLYDEPOTDROP,
+                    AbilityId.TERRANBUILD_SUPPLYDEPOT,
                     [p.offset((2.5, -0.5)) for p in possible],
                 )
                 possible = [p for r, p in zip(res, possible) if r]


### PR DESCRIPTION
Fixes https://github.com/BurnySc2/python-sc2/issues/223
Related to https://github.com/BurnySc2/python-sc2/commit/1ec2d720da842d10e3209c6e46327a3c1e6713cf

This change fixes `find_placement` function to work properly with `addon_place=True`

It can be tested by running the `terran/onebase_battlecruiser.py` example with the following code change:
```py
if self.can_afford(UnitTypeId.STARPORT):
    position = await self.find_placement(
        UnitTypeId.STARPORT,
        near=cc.position - (3, 0),
        placement_step=1,
        addon_place=True,
    )
    if position is not None:
        await self.build(
            UnitTypeId.STARPORT,
            near=position,
        )
```
The `- (3, 0)` forces the function to find a valid position on the left of the main command center.