### PR TITLE
Enhance is_detector to include OBSERVER type

### DIFF
--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -927,7 +927,11 @@ class Unit:
     def is_detector(self) -> bool:
         """Checks if the unit is a detector. Has to be completed
         in order to detect and Photoncannons also need to be powered."""
-        return self.is_ready and (self.type_id in IS_DETECTOR or self.type_id == UNIT_PHOTONCANNON and self.is_powered) or self.type_id == UnitTypeId.OBSERVER
+        return (
+            self.is_ready
+            and (self.type_id in IS_DETECTOR or self.type_id == UNIT_PHOTONCANNON and self.is_powered)
+            or self.type_id == UnitTypeId.OBSERVER
+        )
 
     @property
     def radar_range(self) -> float:

--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -927,7 +927,7 @@ class Unit:
     def is_detector(self) -> bool:
         """Checks if the unit is a detector. Has to be completed
         in order to detect and Photoncannons also need to be powered."""
-        return self.is_ready and (self.type_id in IS_DETECTOR or self.type_id == UNIT_PHOTONCANNON and self.is_powered)
+        return self.is_ready and (self.type_id in IS_DETECTOR or self.type_id == UNIT_PHOTONCANNON and self.is_powered) or self.type_id == UnitTypeId.OBSERVER
 
     @property
     def radar_range(self) -> float:


### PR DESCRIPTION
observers are always ready, but build_progress == 0 unless they are detected.

I considered changing is_ready but build_progress can be < 1 if a mothership is cloaking a warp-in so it would need to specify all the non-warpin units for that to work. That would be more correct for immortals/disruptors/etc that are always ready if they exist but it seemed more fraught.