### PR TITLE
Fix Terran mech armor research ID issues

### DIFF
--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -1337,6 +1337,32 @@ class Unit:
         :param queue:
         :param can_afford_check:
         """
+        # Avoid a bug where Terran mech armor research does not start due to an incorrect exact_id from the protobuf. 
+        # Hardcode the correct ID.
+        if upgrade == UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL1:
+            return self(
+                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL1, 
+                queue=queue, 
+                subtract_cost=True,
+                can_afford_check=can_afford_check,
+            )
+
+        if upgrade == UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL2:
+            return self(
+                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL2, 
+                queue=queue, 
+                subtract_cost=True,
+                can_afford_check=can_afford_check,
+            )
+
+        if upgrade == UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL3:
+            return self(
+                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL3, 
+                queue=queue, 
+                subtract_cost=True,
+                can_afford_check=can_afford_check,
+            )
+
         return self(
             self._bot_object.game_data.upgrades[upgrade.value].research_ability.exact_id,
             queue=queue,

--- a/sc2/unit.py
+++ b/sc2/unit.py
@@ -1341,24 +1341,24 @@ class Unit:
         # Hardcode the correct ID.
         if upgrade == UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL1:
             return self(
-                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL1, 
-                queue=queue, 
+                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL1,
+                queue=queue,
                 subtract_cost=True,
                 can_afford_check=can_afford_check,
             )
 
         if upgrade == UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL2:
             return self(
-                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL2, 
-                queue=queue, 
+                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL2,
+                queue=queue,
                 subtract_cost=True,
                 can_afford_check=can_afford_check,
             )
 
         if upgrade == UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL3:
             return self(
-                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL3, 
-                queue=queue, 
+                AbilityId.ARMORYRESEARCH_TERRANVEHICLEANDSHIPPLATINGLEVEL3,
+                queue=queue,
                 subtract_cost=True,
                 can_afford_check=can_afford_check,
             )


### PR DESCRIPTION
Prevent research bugs, where Terran mech armor research does not start due to an incorrect exact_id from the protobuf. 
Hardcode correct IDs

For some reason 'exact_id' for UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL1 is returning the ability ID 'ARMORYRESEARCHSWARM_TERRANVEHICLEANDSHIPPLATINGLEVEL1' in the protobuf (with 'SWARM' in the middle)

Similar for upgrade level 2 and 3
UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL1
AbilityId.ARMORYRESEARCHSWARM_TERRANVEHICLEANDSHIPPLATINGLEVEL1 UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL2
AbilityId.ARMORYRESEARCHSWARM_TERRANVEHICLEANDSHIPPLATINGLEVEL2 UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL3
AbilityId.ARMORYRESEARCHSWARM_TERRANVEHICLEANDSHIPPLATINGLEVEL3