### PR TITLE
Fixes Cost.__add__ returning references

### DIFF
--- a/sc2/game_data.py
+++ b/sc2/game_data.py
@@ -325,15 +325,11 @@ class Cost:
         return self.minerals != 0 or self.vespene != 0
 
     def __add__(self, other: Cost) -> Cost:
-        if not other:
-            return self
-        if not self:
-            return other
         time = (self.time or 0) + (other.time or 0)
         return Cost(self.minerals + other.minerals, self.vespene + other.vespene, time=time)
 
     def __sub__(self, other: Cost) -> Cost:
-        time = (self.time or 0) + (other.time or 0)
+        time = (self.time or 0) - (other.time or 0)
         return Cost(self.minerals - other.minerals, self.vespene - other.vespene, time=time)
 
     def __mul__(self, other: int) -> Cost:


### PR DESCRIPTION
This caused a bug for me that took very long to find:

In `Cost.__add__` we return the other cost object if the first one is `(0, 0)` - by reference! This should at least return a copy, but really we don't need this micro optimization here, so I removed the clauses.

I also fixed the time sign in `__sub__`.